### PR TITLE
feat: suppport switching with only session name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,13 +20,10 @@ impl ZellijPlugin for State {
         let session_name = collection[0];
         let layout_name = "default";
         let layout: LayoutInfo = LayoutInfo::File(layout_name.to_string());
-        if collection.len() < 2 {
-            switch_session_with_layout(Some(&session_name), layout, None);
-            close_self();
-            return true;
+        let mut cwd = None;
+        if collection.len() == 2 {
+            cwd = Some(PathBuf::from(collection[1]));
         }
-
-        let cwd = Some(PathBuf::from(collection[1]));
         switch_session_with_layout(Some(&session_name), layout, cwd);
         close_self();
         true

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,15 @@ impl ZellijPlugin for State {
         let session_name = pipe_message.payload.unwrap().to_string();
         let collection: Vec<&str> = session_name.split("::").collect::<Vec<&str>>().clone();
         let session_name = collection[0];
-        let cwd = Some(PathBuf::from(collection[1]));
         let layout_name = "default";
         let layout: LayoutInfo = LayoutInfo::File(layout_name.to_string());
+        if collection.len() < 2 {
+            switch_session_with_layout(Some(&session_name), layout, None);
+            close_self();
+            return true;
+        }
+
+        let cwd = Some(PathBuf::from(collection[1]));
         switch_session_with_layout(Some(&session_name), layout, cwd);
         close_self();
         true


### PR DESCRIPTION
Hi, great work with this, it was just what I needed!

That said, made a small improvement to allow switching to existing sessions without specifying directory.

Something like `zellij pipe --plugin https://github.com/mostafaqanbaryan/zellij-switch/releases/download/v0.1.0/zellij-switch.wasm -- "$session_name"` would work (if the session exists).