### PR TITLE
Add optional third position for specifying layout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Zellij switch
+
 I needed this for my workflow, but it's is not great at all and has a few problems.
 
 But works for me!
@@ -18,4 +19,5 @@ Starting at version 0.2.0, you may additionally specify a layout (without .kdl e
 3. (Optional) For better integration, [use this script](https://github.com/mostafaqanbaryan/dotfiles/blob/main/scripts/sessions)
 
 ## Build
-- Clone the project and run `cargo build --target wasm32-wasi --release`
+
+- Clone the project and run `cargo build --target wasm32-wasip1 --release`

--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@ I needed this for my workflow, but it's is not great at all and has a few proble
 But works for me!
 
 ## Instruction
-1. `zellij pipe --plugin https://github.com/mostafaqanbaryan/zellij-switch/releases/download/v0.1.1/zellij-switch.wasm -- "$session_name::$cwd"`
-   - As of version 0.1.1, this works without specifying `$cwd`:
-   - `zellij pipe --plugin https://github.com/mostafaqanbaryan/zellij-switch/releases/download/v0.1.1/zellij-switch.wasm -- "$session_name"`
+
+    zellij pipe --plugin https://github.com/mostafaqanbaryan/zellij-switch/releases/download/v0.1.1/zellij-switch.wasm -- "$session_name::$cwd"
+
+As of version 0.1.1, this works without specifying `$cwd`:
+
+    zellij pipe --plugin https://github.com/mostafaqanbaryan/zellij-switch/releases/download/v0.1.1/zellij-switch.wasm -- "$session_name"
+
+Starting at version 0.2.0, you may additionally specify a layout (without .kdl extension) in the third position:
+
+    zellij pipe --plugin https://github.com/mostafaqanbaryan/zellij-switch/releases/download/v0.2.0/zellij-switch.wasm -- "$session_name::$cwd::$layout"
+
 3. (Optional) For better integration, [use this script](https://github.com/mostafaqanbaryan/dotfiles/blob/main/scripts/sessions)
 
 ## Build

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ impl ZellijPlugin for State {
         };
 
         let layout = LayoutInfo::File(layout_name);
-        switch_session_with_layout(Some(session_name), layout, cwd);
+        switch_session_with_layout(Some(&session_name), layout, cwd);
         close_self();
         true
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,21 +19,15 @@ impl ZellijPlugin for State {
         let collection: Vec<&str> = session_name.split("::").collect::<Vec<&str>>().clone();
 
         let session_name = collection[0];
+        let mut layout_name = "default".to_string();
         let mut cwd = None;
 
-        let layout_name = match collection.len() {
-            2 => {
-                // Original format: session::cwd
-                cwd = Some(PathBuf::from(collection[1]));
-                "default".to_string()
-            }
-            3 => {
-                // New format: session::cwd::layout
-                cwd = Some(PathBuf::from(collection[1]));
-                format!("{}.kdl", collection[2])
-            }
-            _ => "default".to_string(),
-        };
+        if collection.len() >= 2 {
+            cwd = Some(PathBuf::from(collection[1]));
+        }
+        if collection.len() == 3 {
+            layout_name = format!("{}.kdl", collection[2]);
+        }
 
         let layout = LayoutInfo::File(layout_name);
         switch_session_with_layout(Some(&session_name), layout, cwd);


### PR DESCRIPTION
Fixes #3 

With this I can use script:

```fish
#!/usr/bin/env fish

function p # Get git project directory from .projects. See alias repocache.
    set REPO (zoxide query -l | rg --color=never -FxNf ~/.projects | sed s:"$HOME":~: | fzf --reverse)
    if test -n "$REPO"
        string replace '~' $HOME $REPO
    end
end

set -l pdir (p)
if test -z "$pdir"
    exit 1
end

set -l pname (basename $pdir)

if set -q ZELLIJ_SESSION_NAME
    if not string match -q "$pname" "$ZELLIJ_SESSION_NAME"
        zellij pipe --plugin file:~/bin/zellij-switch.wasm -- "$pname::$pdir::editor"
    end
else
    cd $pdir
    if contains $pname (zellij list-sessions -ns)
        if contains $pname (zellij list-sessions -n | rg EXITED | cut -d' ' -f1 | cut -d':' -f2)
            zellij delete-session $pname
            zellij -n editor -s $pname
        else
            zellij attach $pname
        end
    else
        zellij -n editor -s $pname
    end
end
```

And launch with a project configuration.

Let me know what you think.