### PR TITLE
feat: add nix flake and instructions for NixOS installation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+use flake
+
+export PATH=$PATH:$HOME/.local/bin
+export ZELLIJ_SWITCH_PATH=$PWD/result/bin/zellij-switch.wasm

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.direnv
+result*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .direnv
 result*
+.rustc_info.json

--- a/.rustc_info.json
+++ b/.rustc_info.json
@@ -1,1 +1,0 @@
-{"rustc_fingerprint":4084695811017446290,"outputs":{"4614504638168534921":{"success":true,"status":"","code":0,"stdout":"rustc 1.84.0 (9fc6b4312 2025-01-07)\nbinary: rustc\ncommit-hash: 9fc6b43126469e3858e2fe86cafb4f0fd5068869\ncommit-date: 2025-01-07\nhost: x86_64-unknown-linux-gnu\nrelease: 1.84.0\nLLVM version: 19.1.5\n","stderr":""}},"successes":{}}

--- a/.rustc_info.json
+++ b/.rustc_info.json
@@ -1,0 +1,1 @@
+{"rustc_fingerprint":4084695811017446290,"outputs":{"4614504638168534921":{"success":true,"status":"","code":0,"stdout":"rustc 1.84.0 (9fc6b4312 2025-01-07)\nbinary: rustc\ncommit-hash: 9fc6b43126469e3858e2fe86cafb4f0fd5068869\ncommit-date: 2025-01-07\nhost: x86_64-unknown-linux-gnu\nrelease: 1.84.0\nLLVM version: 19.1.5\n","stderr":""}},"successes":{}}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ If you use home-manager or maintain a Nix configuration, you can add `zellij-swi
 }
 ```
 
-2. Add `zellij-switch` to your packages:
+2. Add `zellij-switch` overlay to your `nixpkgs`:
+
+```nix
+{
+  nixpkgs.overlays = [ zellij-switch.overlays.default ];
+}
+```
+
+3. Add `zellij-switch` to your packages:
 
 ```nix
 environment.systemPackages = with pkgs; [
@@ -37,7 +45,7 @@ environment.systemPackages = with pkgs; [
 ];
 ```
 
-3. Apply your configuration:
+4. Apply your configuration:
 
 ```bash
 nixos-rebuild switch

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you use home-manager or maintain a Nix configuration, you can add `zellij-swi
 
 ```nix
 {
-  inputs.zellij-switch.url = "github:yourusername/yourrepo";
+  inputs.zellij-switch.url = "github:mostafaqanbaryan/zellij-switch";
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,3 +16,29 @@ But works for me!
 ## Build
 
 - Clone the project and run `cargo build --target wasm32-wasip1 --release`
+
+## Installation on NixOS
+
+If you use home-manager or maintain a Nix configuration, you can add `zellij-switch` as easy as:
+
+1. Add this flake as an input in your Nix configuration:
+
+```nix
+{
+  inputs.zellij-switch.url = "github:yourusername/yourrepo";
+}
+```
+
+2. Add `zellij-switch` to your packages:
+
+```nix
+environment.systemPackages = with pkgs; [
+  zellij-switch
+];
+```
+
+3. Apply your configuration:
+
+```bash
+nixos-rebuild switch
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,74 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
+        "path": "/nix/store/khbvilmsrv4l69nwd52h27j1mp44a0xi-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1736476219,
+        "narHash": "sha256-+qyv3QqdZCdZ3cSO/cbpEY6tntyYjfe1bB12mdpNFaY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "de30cc5963da22e9742bbbbb9a3344570ed237b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,9 @@
           };
         });
 
+      defaultPackage = eachSystem (system:
+        self.packages.${system}.default);
+
       overlays.default = final: prev: {
         zellij-switch = self.packages.${prev.system}.default;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs";
+    systems.url = "github:nix-systems/default";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = inputs @ { self, nixpkgs, systems, rust-overlay, ... }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
+    in
+    {
+      packages = eachSystem (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ rust-overlay.overlays.default ];
+          };
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            targets = [ "wasm32-wasip1" ];
+          };
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "zellij-switch";
+            version = "0.2.0";
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+            
+            nativeBuildInputs = [ rustToolchain ];
+
+            buildPhase = ''
+              cargo build --target wasm32-wasip1 --release
+            '';
+
+            installPhase = ''
+              mkdir -p $out/bin
+              cp target/wasm32-wasip1/release/*.wasm $out/bin/
+            '';
+
+            doCheck = false;
+          };
+        });
+
+      overlays.default = final: prev: {
+        zellij-switch = self.packages.${prev.system}.default;
+      };
+    };
+}


### PR DESCRIPTION
## Add Flake Support for zellij-switch

This PR adds Nix Flake support, making development and usage easier in Nix environments.

### Advantages:

- For Developers: Provides a reproducible environment with dependencies pre-configured, ideal for plugin development.
- For Users: Simplifies installation as a Nix package, so it can easily be added into their configurations.