### PR TITLE
feat: add session tracking and switch by index support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,1 @@
 use flake
-
-export PATH=$PATH:$HOME/.local/bin
-export ZELLIJ_SWITCH_PATH=$PWD/result/bin/zellij-switch.wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -1102,7 +1102,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -1754,7 +1754,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2069,7 +2069,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2142,7 +2142,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2180,7 +2180,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2302,9 +2302,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2661,7 +2661,7 @@ checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3029,9 +3029,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "678faa00651c9eb72dd2020cbdf275d92eccb2400d568e419efdd64838145cb4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3166,7 +3166,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3268,7 +3268,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3519,7 +3519,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.113",
  "wasm-bindgen-shared",
 ]
 
@@ -3553,7 +3553,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.113",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3841,9 +3841,9 @@ dependencies = [
 
 [[package]]
 name = "zellij-tile"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58471198b62771e4387ac00c072e9b1d8ebd87db2568bdb5fbb60dd99d8552bd"
+checksum = "43cd7459277f12a843b3edba8ed44e32ee8f79a76cc26f165d65c09f1441377b"
 dependencies = [
  "clap",
  "serde",
@@ -3855,9 +3855,9 @@ dependencies = [
 
 [[package]]
 name = "zellij-utils"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5289f6ff643db4f7f772f090cede454cd1be276a3a5654464c402094b625524f"
+checksum = "019bf9a4795c67b97da79851f59f3f3970255d1f3e7a6dff4e1033366ca27009"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/flake.nix
+++ b/flake.nix
@@ -48,5 +48,24 @@
       overlays.default = final: prev: {
         zellij-switch = self.packages.${prev.system}.default;
       };
+
+      devShells = eachSystem (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ rust-overlay.overlays.default ];
+          };
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [ "rust-src" "rust-analyzer" ];
+            targets = [ "wasm32-wasip1" ];
+          };
+        in
+        {
+          default = pkgs.mkShell {
+            nativeBuildInputs = [
+              rustToolchain
+            ];
+          };
+        });
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,21 +51,6 @@ impl ZellijPlugin for State {
         subscribe(&[EventType::SessionUpdate]);
     }
 
-    fn update(&mut self, event: Event) -> bool {
-        if let Event::SessionUpdate(session_infos, _) = event {
-            let active_sessions: Vec<String> =
-                session_infos.iter().map(|s| s.name.clone()).collect();
-
-            self.sessions.retain(|s| active_sessions.contains(s));
-            for name in active_sessions {
-                if !self.sessions.contains(&name) {
-                    self.sessions.push(name);
-                }
-            }
-        }
-        false
-    }
-
     fn pipe(&mut self, pipe_message: PipeMessage) -> bool {
         let payload = pipe_message.payload.unwrap_or_default();
         let parser = Parser::from_args(shell_words::split(&payload).unwrap_or_default());
@@ -73,6 +58,7 @@ impl ZellijPlugin for State {
         let Ok(args) = parse_args(parser) else {
             return false;
         };
+
         let Some(target) = args.target else {
             return false;
         };
@@ -92,6 +78,14 @@ impl ZellijPlugin for State {
             switch_session_with_layout(Some(&name), layout_to_use, args.cwd);
         }
 
+        false
+    }
+
+    fn update(&mut self, event: Event) -> bool {
+        if let Event::SessionUpdate(session_infos, _) = event {
+            self.sessions = session_infos.iter().map(|s| s.name.clone()).collect();
+            self.sessions.sort();
+        }
         false
     }
 }


### PR DESCRIPTION
## Description

- This change will make the plugin track active sessions and enforce alphabetical ordering to ensure stable switching indices.
- Some improvements to the flake to help with development.

**Note**: this PR adds additional complexity to the plugin and backwards compatibility was not checked by me.

## Motivations behind the PR

- One of the motivations was that some users have found difficulties when trying to use the plugin (see: #12 (might be related) and #11 (I think it's related)), and I think this PR makes it easier for usage and document behavior as well.

- Another one was just to simplify my local setup and have the plugin doing some of the job instead of maintaining multiple shell scripts to interact with it.

## Setup example

On your `Zellij` configuration file:

```kdl
plugins {
    zellij-switch location="file:///plugin/path/zellij-switch.wasm" {
        _internal_ "true"
        name "zellij-switch"
    }
}

load_plugins {
    "zellij-switch"
}
```

## Keybindings

1. Switch between your first 10 active sessions:

```kdl
bind "Alt 0" { MessagePlugin "zellij-switch" { payload "session-index 0"; }; }
bind "Alt 1" { MessagePlugin "zellij-switch" { payload "session-index 1"; }; }
// ... repeat for 2-9
```

2. Scans directories (`~/src`,`~/org` in the example) for git folders, opens a floating pane with `fzf` and creates/switches to a session for the selected location:

```kdl
bind "Ctrl f" {
  Run "bash" "-c" "find ~/src ~/org -maxdepth 5 -name .git | xargs -I{} dirname {} | sort -u | while read -r p; do if [ -f \"$p/.git\" ]; then printf \"%s_%s\t%s\n\" \"$(basename \"$(dirname \"$p\")\")\" \"$(basename \"$p\")\" \"$p\"; else printf \"%s\t%s\n\" \"$(basename \"$p\")\" \"$p\"; fi; done | column -t -s $'\t' | fzf --layout=reverse --header='Select Project' --nth=1 | awk '{print $1, $2}' | xargs -n2 bash -c 'name=$0; cwd=$1; s=$(zellij ls -s 2>/dev/null | grep -E \"(-|^)${name}$\" | head -n1); if [ -z \"$s\" ]; then s=\"$(date +%s)-$name\"; fi; zellij pipe --name zellij-switch -- \"session-select --target $s --cwd $cwd\"'" {
      floating true
      close_on_exit true
      width "70%"
      height "70%"
      x "15%"
      y "15%"
  }
}
```

**Note**: The plugin now sorts sessions alphabetically, but we can prepend a timestamp here so it will follow creation order.

3. Keymap on your WM (for whom would like to open the terminal together with a default session):

```kdl
Mod+Return {
  spawn "bash" "-c" "t='dtsf'; s=$(zellij ls -s 2>/dev/null | grep -E \"(-|^)${t}$\" | sort | head -n1); if [ -n \"$s\" ]; then alacritty -e zellij attach \"$s\"; else alacritty -e zellij attach -c \"$(date +%s)-$t\"; fi"
}
```